### PR TITLE
Negation causes cleanup tasks to run as default is false

### DIFF
--- a/roles/installer/tasks/cleanup.yml
+++ b/roles/installer/tasks/cleanup.yml
@@ -27,4 +27,4 @@
         - '{{ ansible_operator_meta.name }}-receptor-work-signing'
       no_log: "{{ no_log }}"
 
-  when: not garbage_collect_secrets | bool
+  when: garbage_collect_secrets | bool


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #1190
Due to the negation in the where clause, the cleanup tasks always run due to the default being false. Since our secrets are owned by another controller, this causes the awx controller to behave in weird ways.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Bug, Docs Fix or other nominal change
